### PR TITLE
Move logic from ``TraceItem`` to ``TraceabilityMatrix``

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,5 @@
 name: CI
-on: 
+on:
   pull_request:
     branches:
     - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,9 @@ jobs:
           poetry-version: 1.1.7
       - name: Configure Poetry
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+      - name: Combine Readme and Changelog for PyPI
+        run: |
+          cp README.md README_ONLY.md
+          cat README_ONLY.md CHANGELOG.md > README.md
       - name: Publish package
         run: poetry publish --build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+ci:
+  skip: [pylint]
+
 exclude: tests/functional/data
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+# Changelog
+
+## V1.0.0
+### API changes:
+* ``TraceItem`` has been degraded to a simple dataclass. The methods ``get_by_id`` and ``add_trace`` have been removed. Adding items (rows or columns) to a ``TraceabilityMatrix`` is now done by using ``TraceabilityMatrix.add_row(row_id)`` and ``TraceabilityMatrix.add_column(column_id)``. Traces between rows and columns are created by calling ``TraceabilityMatrix.add_trace(row_id, column_id)``. To all these methods, the ``id`` is passed as a string. The end user does not need to work with the ``TraceItem`` class any more.

--- a/README.md
+++ b/README.md
@@ -8,33 +8,34 @@ As the APIs and export formats of different test management and/or requirement m
 ## How to use this package
 Currently it is only possible to use this package programmatically in your own script.
 
-All traceable items have a unique ``id`` and a set of other items that they are traced to.
-
-To get an existing or create a new item, you can use the class method ``get_by_id(id_)``.
-It will only create a new instance if no existing item with this ``id`` could be found.
-This means that you don't have to keep track if you already processed this item, because
-some items could appear more than once in your data (i.e. a requirement could appear on multiple test cases).
-
-```python
-from tracematrix.item import TraceItem
-
-req1 = TraceItem.get_by_id("REQ_1")
-testcase1 = TraceItem.get_by_id("TC_1")
-```
-
-Creating links between to items is done by simply passing the two items to ``TraceItem.add_trace(first, second)``.
-This will create a bidirectional link between these elements and update the ``traced_to`` attribute on both.
-
-```python
-TraceItem.add_trace(req1, testcase1)
-```
-
-Currently two output formats are supported - CSV and HTML.
-Default is CSV, but you can specify the reporter when creating the ``TraceabilityMatrix``:
-
-```python
+You start by creating an instance of ``TraceabilityMatrix``.
+The output format is controlled by the ``reporter`` parameter.
+By default ``CsvReporter`` is used, but you can also generate HTML output by passing ``HtmlReporter``.
+```Python
+from tracematrix.matrix import TraceabilityMatrix
 from tracematrix.reporters import HtmlReporter
 
-matrix = TraceabilityMatrix(testcases, requirements, reporter=HtmlReporter)
-matrix.create_matrix("RequirementsTraceabilityMatrix.html")
+matrix = TraceabilityMatrix(reporter=HtmlReporter)
+```
+
+In the next step you add rows and columns to the ``matrix``. Rows and columns can represent anything
+which may be traced against each other. Let's assume that we want to see traces between requirements and test cases.
+This is where your own logic comes into play - the way you determine which items exist and what is traced against each other is up to you and what the source of your data is. For this example, we just use some hardcoded values.
+```Python
+for testcase_id in ("TC_1", "TC_2", "TC_3"):
+    matrix.add_row(testcase_id)
+for requirement_id in ("REQ_1", "REQ_2", "REQ_3", "REQ_4"):
+    matrix.add_column(requirement_id)
+
+matrix.add_trace("TC_1", "REQ_1")
+matrix.add_trace("TC_2", "REQ_2")
+matrix.add_trace("TC_2", "REQ_3")
+```
+Note that rows and columns must be unique - you cannot have two rows or two columns with the same ``id``.
+When you add a trace between a row and a column, the ``TraceabilityMatrix`` will look up the corresponding
+``TraceItem`` instances itself.
+
+Finally, you can save the output to disk:
+```Python
+matrix.write_matrix("traceability_matrix.html)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ description = "Tool to create a traceability matrix"
 authors = ["Andreas Finkler"]
 license = "MIT License"
 readme = "README.md"
+homepage = "https://github.com/DudeNr33/tracematrix"
+keywords = ["requirements", "traceability", "testing", "requirements engineering"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Quality Assurance"
+]
 
 [tool.poetry.dependencies]
 python = "^3.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tracematrix"
-version = "0.3.1"
+version = "1.0.0"
 description = "Tool to create a traceability matrix"
 authors = ["Andreas Finkler"]
 license = "MIT License"

--- a/src/tracematrix/item.py
+++ b/src/tracematrix/item.py
@@ -1,30 +1,10 @@
-"""Definition of trace items."""
-from typing import Dict, Set
+from dataclasses import dataclass, field
+from typing import Set
 
 
+@dataclass(eq=False)
 class TraceItem:
     """Represents an artifact which can be traced bidirectionally to other artifacts."""
 
-    _registry: Dict[str, "TraceItem"] = {}
-
-    def __init__(self, id_: str, traced_to: Set["TraceItem"] = None):
-        self.id = id_  # pylint: disable=invalid-name
-        self.traced_to = traced_to or set()
-
-    @classmethod
-    def get_by_id(cls, id_):
-        """
-        Retrieve an existing TraceItem by its id, or create a new instance if no TraceItem with this id exists.
-        """
-        if id_ in cls._registry:
-            item = cls._registry[id_]
-        else:
-            item = cls(id_)
-            cls._registry[id_] = item
-        return item
-
-    @staticmethod
-    def add_trace(first: "TraceItem", second: "TraceItem"):
-        """Add a bidirectional trace between the two items."""
-        first.traced_to.add(second)
-        second.traced_to.add(first)
+    id: str  # pylint: disable=invalid-name
+    traced_to: Set["TraceItem"] = field(default_factory=set)

--- a/src/tracematrix/matrix.py
+++ b/src/tracematrix/matrix.py
@@ -1,5 +1,5 @@
-"""Definition of the TraceabilityMatrix."""
-from typing import List, Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Union
 
 from tracematrix.item import TraceItem
 from tracematrix.reporters import CsvReporter, Reporter
@@ -7,6 +7,7 @@ from tracematrix.reporters import CsvReporter, Reporter
 
 class TraceabilityMatrix:
     """Represents a traceability matrix which shows the traces between two sets of TraceItems."""
+
     def __init__(
         self,
         rows: Optional[List[TraceItem]] = None,
@@ -16,7 +17,36 @@ class TraceabilityMatrix:
         self.rows = rows or []
         self.columns = columns or []
         self.reporter = reporter()
+        self._row_registry: Dict[str, TraceItem] = {row.id: row for row in self.rows}
+        self._column_registry: Dict[str, TraceItem] = {
+            col.id: col for col in self.columns
+        }
 
-    def write_matrix(self, outputfile):
+    def add_row(self, row_id: str) -> None:
+        if row_id in self._row_registry:
+            raise ValueError("A row with this id already exists.")
+        new_row = TraceItem(row_id)
+        self._row_registry[row_id] = new_row
+        self.rows.append(new_row)
+
+    def add_column(self, column_id: str) -> None:
+        if column_id in self._column_registry:
+            raise ValueError("A column with this id already exists.")
+        new_column = TraceItem(column_id)
+        self._column_registry[column_id] = new_column
+        self.columns.append(new_column)
+
+    def add_trace(self, row_id: str, column_id: str) -> None:
+        """Create a bidirectional trace between a row and a column."""
+        try:
+            row_item = self._row_registry[row_id]
+            column_item = self._column_registry[column_id]
+        except KeyError as exc:
+            raise KeyError("Could not find the specified row or column") from exc
+        else:
+            row_item.traced_to.add(column_item)
+            column_item.traced_to.add(row_item)
+
+    def write_matrix(self, outputfile: Union[Path, str]) -> None:
         """Create the matrix and write it to the given output file."""
         self.reporter.write(outputfile, self.rows, self.columns)

--- a/src/tracematrix/reporters/base_reporter.py
+++ b/src/tracematrix/reporters/base_reporter.py
@@ -15,6 +15,6 @@ class Reporter(ABC):
     @staticmethod
     @abstractmethod
     def write(
-        outputfile: str, testcases: List[TraceItem], requirements: List[TraceItem]
+        outputfile: str, rows: List[TraceItem], columns: List[TraceItem]
     ) -> None:
         """Create the output file and save it to disk."""

--- a/src/tracematrix/reporters/csv_reporter.py
+++ b/src/tracematrix/reporters/csv_reporter.py
@@ -12,19 +12,19 @@ class CsvReporter(Reporter):
     """Creates reports in .csv format"""
     @staticmethod
     def write(
-        outputfile: str, testcases: List[TraceItem], requirements: List[TraceItem]
+        outputfile: str, rows: List[TraceItem], columns: List[TraceItem]
     ) -> None:
-        fieldnames = [""] + [req.id for req in requirements] + ["total"]
+        fieldnames = [""] + [req.id for req in columns] + ["total"]
         with open(outputfile, "w", encoding="utf8") as outfile:
             writer = csv.DictWriter(outfile, fieldnames, delimiter=";")
             writer.writeheader()
-            for testcase in testcases:
+            for testcase in rows:
                 rowdict = {"": testcase.id}
                 for traced_req in testcase.traced_to:
                     rowdict[traced_req.id] = "x"
                 rowdict["total"] = len(testcase.traced_to)
                 writer.writerow(rowdict)
             result_row = {"": "total"}
-            for req in requirements:
+            for req in columns:
                 result_row[req.id] = len(req.traced_to)
             writer.writerow(result_row)

--- a/src/tracematrix/reporters/html_reporter.py
+++ b/src/tracematrix/reporters/html_reporter.py
@@ -21,9 +21,9 @@ class HtmlReporter(Reporter):
 
     @classmethod
     def write(
-        cls, outputfile: str, testcases: List[TraceItem], requirements: List[TraceItem]
+        cls, outputfile: str, rows: List[TraceItem], columns: List[TraceItem]
     ) -> None:
         with open(outputfile, "w", encoding="utf8") as outfile:
             outfile.write(
-                cls.template.render(testcases=testcases, requirements=requirements)
+                cls.template.render(rows=rows, columns=columns)
             )

--- a/src/tracematrix/reporters/template.html
+++ b/src/tracematrix/reporters/template.html
@@ -4,47 +4,47 @@
     <table>
         <tr>
             <th></th>
-            {% for req in requirements -%}
-                {%- if req.traced_to|length == 0 -%}
-                    <th class="untraced">{{ req.id }}</th>
+            {% for column in columns -%}
+                {%- if column.traced_to|length == 0 -%}
+                    <th class="untraced">{{ column.id }}</th>
                 {%- else -%}
-                    <th>{{ req.id }}</th>
+                    <th>{{ column.id }}</th>
                 {%- endif %}
             {% endfor -%}
             <th class="total">Total</th>
         </tr>
-        {%- for tc in testcases %}
-        {% if tc.traced_to|length == 0 -%}
+        {%- for row in rows %}
+        {% if row.traced_to|length == 0 -%}
             <tr class="untraced">
         {%- else -%}
             <tr>
         {%- endif %}
-            <td class="rowitem">{{ tc.id }}</td>
-            {% for req in requirements %}
-                {%- if req in tc.traced_to -%}
+            <td class="rowitem">{{ row.id }}</td>
+            {% for column in columns %}
+                {%- if column in row.traced_to -%}
                     <td>x</td>
                 {%- else -%}
-                    {%- if req.traced_to|length == 0 -%}
+                    {%- if column.traced_to|length == 0 -%}
                         <td class="untraced"></td>
                     {%- else -%}
                         <td></td>
                     {%- endif -%}
                 {%- endif %}
             {% endfor -%}
-            {% if tc.traced_to|length == 0 -%}
-                <td class="untraced">{{ tc.traced_to|length }}</td>
+            {% if row.traced_to|length == 0 -%}
+                <td class="untraced">{{ row.traced_to|length }}</td>
             {%- else -%}
-                <td class="total">{{ tc.traced_to|length }}</td>
+                <td class="total">{{ row.traced_to|length }}</td>
             {%- endif %}
         </tr>
         {%- endfor %}
         <tr class="total">
             <td>Total</td>
-            {% for req in requirements -%}
-                {%- if req.traced_to|length == 0 -%}
+            {% for column in columns -%}
+                {%- if column.traced_to|length == 0 -%}
                     <td class="untraced">0</td>
                 {%- else -%}
-                    <td>{{ req.traced_to|length }}</td>
+                    <td>{{ column.traced_to|length }}</td>
                 {%- endif %}
             {% endfor -%}
             <td></td>

--- a/tests/functional/test_matrix_creation.py
+++ b/tests/functional/test_matrix_creation.py
@@ -2,7 +2,6 @@
 import pytest
 from tracematrix import reporters
 
-from tracematrix.item import TraceItem
 from tracematrix.matrix import TraceabilityMatrix
 
 
@@ -14,19 +13,14 @@ from tracematrix.matrix import TraceabilityMatrix
     ],
 )
 def test_matrix_creation(tmpdir, datadir, reporter, filename):
-    tc1 = TraceItem("TC_1")
-    tc2 = TraceItem("TC_2")
-    tc3 = TraceItem("TC_3")
-    req1 = TraceItem("REQ_1")
-    req2 = TraceItem("REQ_2")
-    req3 = TraceItem("REQ_3")
-    req4 = TraceItem("REQ_4")
-    TraceItem.add_trace(tc1, req1)
-    TraceItem.add_trace(tc2, req2)
-    TraceItem.add_trace(tc2, req3)
-    matrix = TraceabilityMatrix(
-        (tc1, tc2, tc3), (req1, req2, req3, req4), reporter=reporter
-    )
+    matrix = TraceabilityMatrix(reporter=reporter)
+    for testcase_id in ("TC_1", "TC_2", "TC_3"):
+        matrix.add_row(testcase_id)
+    for requirement_id in ("REQ_1", "REQ_2", "REQ_3", "REQ_4"):
+        matrix.add_column(requirement_id)
+    matrix.add_trace("TC_1", "REQ_1")
+    matrix.add_trace("TC_2", "REQ_2")
+    matrix.add_trace("TC_2", "REQ_3")
     actual_output = tmpdir / filename
     expected_output = datadir / filename
     matrix.write_matrix(actual_output)

--- a/tests/unittests/test_item.py
+++ b/tests/unittests/test_item.py
@@ -1,19 +1,12 @@
-import pytest
-
 from tracematrix.item import TraceItem
 
-@pytest.fixture(autouse=True)
-def clear_registry():
-    """All tests should start with an empty registry of TraceItems."""
-    TraceItem._registry.clear()  # pylint: disable=protected-access
 
-
-
-class TestCreation:
+class TestItemCreation:
     """Unit tests focussing on the way TraceItem instances can be created"""
+
     @staticmethod
     def test_direct_instantiation():
-        item = TraceItem(id_="TEST1")
+        item = TraceItem(id="TEST1")
         assert item.id == "TEST1"
         assert len(item.traced_to) == 0
 
@@ -23,29 +16,3 @@ class TestCreation:
         item = TraceItem("R1", traced_to=traced)
         assert item.id == "R1"
         assert item.traced_to == traced
-
-
-class TestRegistry:
-    """Unit tests focussing on the behaviour of the registry and get_by_id method."""
-    @staticmethod
-    def test_create_new_if_not_found():
-        item = TraceItem.get_by_id("REQ1")
-        assert item.id == "REQ1"
-
-    @staticmethod
-    def test_get_existing_if_present1():
-        """Case 1: the original instance was created using the ``get_by_id`` method"""
-        original_req = TraceItem.get_by_id("REQ1")
-        new_req = TraceItem.get_by_id("REQ1")
-        assert new_req is original_req
-
-
-class TestAddTrace:
-    """Unit tests focussing on the ``add_trace`` method."""
-    @staticmethod
-    def test_adds_bidirectional_link():
-        req = TraceItem.get_by_id("req")
-        test = TraceItem.get_by_id("test")
-        TraceItem.add_trace(req, test)
-        assert req in test.traced_to
-        assert test in req.traced_to

--- a/tests/unittests/test_matrix.py
+++ b/tests/unittests/test_matrix.py
@@ -1,9 +1,11 @@
 from tracematrix import matrix, reporters
+
 from tracematrix.item import TraceItem
 
 
-class TestCreation:
+class TestMatrixCreation:
     """Unit tests concerning the initialization of a TraceabilityMatrix object."""
+
     @staticmethod
     def test_defaults():
         mymatrix = matrix.TraceabilityMatrix()


### PR DESCRIPTION
Currently the logic of keeping track of existing ``TraceItem`` instances and adding traces between them is done inside the ``TraceItem`` class itself.

This has several disadvantages:
* There is only one registry for all types of ``TraceItem``s 
* If a user chooses to instantiate a ``TraceItem`` directly (without using ``get_by_id``), this instance is not added to the registry
* The user has to deal with both ``TraceabilityMatrix`` and ``TraceItem``, and build two lists of items (e.g. testcases and requirements) which then need to be passed into ``TraceabilityMatrix``.

Moving this logic into ``TraceabilityMatrix`` makes it more convenient and less error prone to use the package.
See the updated ``README.md`` for details how the package should be used now.